### PR TITLE
Bmailloux/small fixes

### DIFF
--- a/pagination.js
+++ b/pagination.js
@@ -45,6 +45,7 @@ class Pagination extends RtlMixin(LocalizeMixin(LitElement)) {
 
 			.page-max {
 				margin-right: .25rem;
+				white-space: nowrap;
 			}
 
 			.d2l-input-select {

--- a/pagination.js
+++ b/pagination.js
@@ -146,7 +146,12 @@ class Pagination extends RtlMixin(LocalizeMixin(LitElement)) {
 			<d2l-button-icon icon="d2l-tier1:chevron-right" @click="${this._navToNextPage}" text="${this.localize('page_next')}" ?disabled=${this.disableNextPageButton()}></d2l-button-icon>
 
 			${this.showItemCountSelect ? html`
-				<select title="${this.localize('page_size_title')}" class="d2l-input-select" @change="${this._pageCounterChange}">
+				<select
+					aria-label="${this.localize('page_size_title')}"
+					title="${this.localize('page_size_title')}"
+					class="d2l-input-select"
+					@change="${this._pageCounterChange}"
+				>
 					${this.itemCountOptions.map(item => html`
 						<option ?selected="${this.selectedCountOption === item}" value="${item}">${this.localize('page_size_option', 'count', item)}</option>
 					`)}

--- a/pagination.js
+++ b/pagination.js
@@ -81,6 +81,12 @@ class Pagination extends RtlMixin(LocalizeMixin(LitElement)) {
 		this.dispatchEvent(event);
 	}
 
+	_handleKeydown(e) {
+		if (e.key === 'Enter') {
+			this._submitPageNumber(e);
+		}
+	}
+
 	_navToPreviousPage() {
 		const newPageNumber = this.pageNumber - 1;
 		const event = new CustomEvent('pagination-page-change', {
@@ -138,10 +144,16 @@ class Pagination extends RtlMixin(LocalizeMixin(LitElement)) {
 		return html`
 		<div class="pagination-container">
 			<d2l-button-icon icon="d2l-tier1:chevron-left" @click="${this._navToPreviousPage}" text="${this.localize('page_previous')}" ?disabled=${this.disablePreviousPageButton()}></d2l-button-icon>
-			<d2l-input-text class="page-number"
-			autocomplete="off"
-			autocorrect="off"
-			type="text" aria-label="page_number_title" value="${this.pageNumber}" @blur="${this._submitPageNumber}"></d2l-input-text>
+			<d2l-input-text
+				class="page-number"
+				autocomplete="off"
+				autocorrect="off"
+				type="text"
+				aria-label="page_number_title"
+				value="${this.pageNumber}"
+				@blur="${this._submitPageNumber}"
+				@keydown="${this._handleKeydown}"
+			></d2l-input-text>
 			<span class="page-max">∕ ${this.maxPageNumber}</span>
 			<d2l-button-icon icon="d2l-tier1:chevron-right" @click="${this._navToNextPage}" text="${this.localize('page_next')}" ?disabled=${this.disableNextPageButton()}></d2l-button-icon>
 

--- a/test/pagination.html
+++ b/test/pagination.html
@@ -19,18 +19,32 @@
 			</template>
 		</test-fixture>
 
+		<test-fixture id="full">
+			<template>
+				<d2l-labs-pagination
+					pageNumber="1"
+					maxPageNumber="6"
+					showItemCountSelect="true"
+					itemCountOptions="[10,20,50,100]"
+					selectedCountOption="20"
+				></d2l-labs-pagination>
+			</template>
+		</test-fixture>
+
 		<script type="module">
 			import { runAxe } from '@brightspace-ui/core/tools/a11y-test-helper.js';
 
 			describe('d2l-labs-pagination', () => {
-				let element;
 
-				beforeEach(async() => {
-					element = fixture('basic');
+				it('should pass all axe tests (basic)', async() => {
+					const element = fixture('basic');
 					await element.updateComplete;
+					await runAxe(element);
 				});
 
-				it('should pass all axe tests', async() => {
+				it('should pass all axe tests (full)', async() => {
+					const element = fixture('full');
+					await element.updateComplete;
 					await runAxe(element);
 				});
 


### PR DESCRIPTION
Fixes #7 
Fixes #8 
Fixes #9

Testing
* Added an automated test for the axe issue (#7)
  * Manual test cases
    * Changing page number and pressing Enter triggers page change
    * Not change page number and pressing Enter does not trigger page change
    * Small screen does not stack max pages and separator text
  * Browsers (large and small screens for all)
    * Chrome desktop
    * FF desktop
    * Edgium desktop
    * Edge legacy desktop
* One remaining issue: on small screens the page selector overflows outside of the page (#11):

![image](https://user-images.githubusercontent.com/11587338/90276620-38bf1780-de32-11ea-8147-060d771839f6.png)

@BhamelinD2L Is there anything special I need to do to deploy a new version? Or will Travis just handle it?