### PR TITLE
Center and stack page controls

### DIFF
--- a/pagination.js
+++ b/pagination.js
@@ -23,15 +23,34 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 	static get styles() {
 		return [selectStyles, css`
 			:host {
-				display: inline-block;
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+				align-content: center;
+				justify-content: center;
+				white-space: nowrap;
 			}
+
 			:host([hidden]) {
 				display: none;
 			}
 
+			@media (max-width: 544px) {
+				:host {
+					flex-direction: column-reverse;
+				}
+			}
+
 			.pagination-container {
-				display: flex;
-				align-items: center;
+				display: block;
+			}
+
+			.page-selector-container {
+				margin: 15px;
+			}
+
+			.page-selector-container > * {
+				display: inline-flex;
 			}
 
 			.page-number {
@@ -42,11 +61,7 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 
 			.page-max {
 				margin-right: .25rem;
-				white-space: nowrap;
-			}
-
-			.d2l-input-select {
-				margin-left: 1rem;
+				vertical-align: middle;
 			}
 		`];
 	}
@@ -136,33 +151,36 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 
 	render() {
 		return html`
-		<div class="pagination-container">
-			<d2l-button-icon icon="d2l-tier1:chevron-left" @click="${this._navToPreviousPage}" text="${this.localize('page_previous')}" ?disabled=${this.disablePreviousPageButton()}></d2l-button-icon>
-			<d2l-input-text
-				class="page-number"
-				autocomplete="off"
-				autocorrect="off"
-				type="text"
-				aria-label="page_number_title"
-				value="${this.pageNumber}"
-				@blur="${this._submitPageNumber}"
-				@keydown="${this._handleKeydown}"
-			></d2l-input-text>
-			<span class="page-max">∕ ${this.maxPageNumber}</span>
-			<d2l-button-icon icon="d2l-tier1:chevron-right" @click="${this._navToNextPage}" text="${this.localize('page_next')}" ?disabled=${this.disableNextPageButton()}></d2l-button-icon>
+			<div class="pagination-container page-selector-container">
+				<d2l-button-icon icon="d2l-tier1:chevron-left" @click="${this._navToPreviousPage}" text="${this.localize('page_previous')}" ?disabled=${this.disablePreviousPageButton()}></d2l-button-icon>
+				<d2l-input-text
+					class="page-number"
+					autocomplete="off"
+					autocorrect="off"
+					type="text"
+					aria-label="page_number_title"
+					value="${this.pageNumber}"
+					@blur="${this._submitPageNumber}"
+					@keydown="${this._handleKeydown}"
+				></d2l-input-text>
+				<span class="page-max">/ ${this.maxPageNumber}</span>
+				<d2l-button-icon icon="d2l-tier1:chevron-right" @click="${this._navToNextPage}" text="${this.localize('page_next')}" ?disabled=${this.disableNextPageButton()}></d2l-button-icon>
+			</div>
 
 			${this.showItemCountSelect ? html`
-				<select
-					aria-label="${this.localize('page_size_title')}"
-					title="${this.localize('page_size_title')}"
-					class="d2l-input-select"
-					@change="${this._pageCounterChange}"
-				>
-					${this.itemCountOptions.map(item => html`
-						<option ?selected="${this.selectedCountOption === item}" value="${item}">${this.localize('page_size_option', 'count', item)}</option>
-					`)}
-				</select>` : null }
-		</div>
+				<div class="pagination-container">
+					<select
+						aria-label="${this.localize('page_size_title')}"
+						title="${this.localize('page_size_title')}"
+						class="d2l-input-select"
+						@change="${this._pageCounterChange}"
+					>
+						${this.itemCountOptions.map(item => html`
+							<option ?selected="${this.selectedCountOption === item}" value="${item}">${this.localize('page_size_option', 'count', item)}</option>
+						`)}
+					</select>
+				</div>
+			` : null }
 		`;
 	}
 }

--- a/pagination.js
+++ b/pagination.js
@@ -163,7 +163,8 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 					@blur="${this._submitPageNumber}"
 					@keydown="${this._handleKeydown}"
 				></d2l-input-text>
-				<span class="page-max">/ ${this.maxPageNumber}</span>
+				<!-- Note: this uses a division slash rather than a regular slash -->
+				<span class="page-max">∕ ${this.maxPageNumber}</span>
 				<d2l-button-icon icon="d2l-tier1:chevron-right" @click="${this._navToNextPage}" text="${this.localize('page_next')}" ?disabled=${this.disableNextPageButton()}></d2l-button-icon>
 			</div>
 

--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -35,11 +35,13 @@ describe('pagination', () => {
 
 	describe('render', () => {
 		it('should render page number and max page number correctly', async() => {
-			const el = await fixture(html`<d2l-labs-pagination pageNumber="3" maxPageNumber="8"></d2l-labs-pagination>`);
+			const el = await fixture(
+				html`<d2l-labs-pagination pageNumber="3" maxPageNumber="8"></d2l-labs-pagination>`
+			);
 			const pageInput = el.shadowRoot.querySelector('d2l-input-text');
 			const maxPageIndicator = el.shadowRoot.querySelector('span.page-max');
 			expect(pageInput.value).to.equal('3');
-			expect(maxPageIndicator.innerText).to.equal('∕ 8'); // this isn't a regular slash
+			expect(maxPageIndicator.innerText).to.equal('/ 8');
 
 			// by default, it should not render the page size selector
 			const pageSizeSelector = el.shadowRoot.querySelector('select');
@@ -59,7 +61,7 @@ describe('pagination', () => {
 			const pageNumberInput = el.shadowRoot.querySelector('d2l-input-text');
 			const maxPageIndicator = el.shadowRoot.querySelector('span.page-max');
 			expect(pageNumberInput.value).to.equal('3');
-			expect(maxPageIndicator.innerText).to.equal('∕ 8'); // this isn't a regular slash
+			expect(maxPageIndicator.innerText).to.equal('/ 8');
 
 			const pageSizeSelector = el.shadowRoot.querySelector('select');
 			expect(pageSizeSelector).to.not.be.null;
@@ -90,13 +92,13 @@ describe('pagination', () => {
 			}
 
 			describe('ltr', () => {
-				it('should disable left button (ltr)', async() => {
+				it('should disable left button', async() => {
 					const {leftButton, rightButton} = await getPaginationEl(1, 5, 'ltr');
 					expect(leftButton.disabled).to.be.true;
 					expect(rightButton.disabled).to.be.false;
 				});
 
-				it('should disable right button (ltr)', async() => {
+				it('should disable right button', async() => {
 					const {leftButton, rightButton} = await getPaginationEl(5, 5, 'ltr');
 					expect(leftButton.disabled).to.be.false;
 					expect(rightButton.disabled).to.be.true;
@@ -122,17 +124,17 @@ describe('pagination', () => {
 			});
 
 			describe('rtl', () => {
-				// in rtl, the "left" button is actually on the right side and mirrored so it looks like a right arrow
-				// so the "left" button is still the one that is disabled, even though it's really the right button
-				// (and vice-versa for the "right" button, which is actually on the left)
 
-				it('should disable left button (rtl)', async() => {
+				// in rtl, the "left" button is actually on the right side and mirrored so it looks like a right arrow
+				// so on page 1, the "left" button is still the one that's disabled, even though it's really the button
+				// on the right side (and vice-versa for the "right" button, which is actually on the left side)
+				it('should disable left button', async() => {
 					const {leftButton, rightButton} = await getPaginationEl(1, 5, 'rtl');
 					expect(leftButton.disabled).to.be.true;
 					expect(rightButton.disabled).to.be.false;
 				});
 
-				it('should disable right button (rtl)', async() => {
+				it('should disable right button', async() => {
 					const {leftButton, rightButton} = await getPaginationEl(5, 5, 'rtl');
 					expect(leftButton.disabled).to.be.false;
 					expect(rightButton.disabled).to.be.true;

--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -41,7 +41,7 @@ describe('pagination', () => {
 			const pageInput = el.shadowRoot.querySelector('d2l-input-text');
 			const maxPageIndicator = el.shadowRoot.querySelector('span.page-max');
 			expect(pageInput.value).to.equal('3');
-			expect(maxPageIndicator.innerText).to.equal('/ 8');
+			expect(maxPageIndicator.innerText).to.equal('∕ 8');
 
 			// by default, it should not render the page size selector
 			const pageSizeSelector = el.shadowRoot.querySelector('select');
@@ -61,7 +61,7 @@ describe('pagination', () => {
 			const pageNumberInput = el.shadowRoot.querySelector('d2l-input-text');
 			const maxPageIndicator = el.shadowRoot.querySelector('span.page-max');
 			expect(pageNumberInput.value).to.equal('3');
-			expect(maxPageIndicator.innerText).to.equal('/ 8');
+			expect(maxPageIndicator.innerText).to.equal('∕ 8');
 
 			const pageSizeSelector = el.shadowRoot.querySelector('select');
 			expect(pageSizeSelector).to.not.be.null;


### PR DESCRIPTION
Mimics the following parts of page selector styles on MVC pages:
- centered
- on small screens, stack the page size selector and page selector boxes on top of each other, rather than letting them overflow outside of the page

Before
![image](https://user-images.githubusercontent.com/11587338/90426838-afa51c00-e08f-11ea-8711-fe78ea5a78ee.png)

After
![image](https://user-images.githubusercontent.com/11587338/90426913-d19e9e80-e08f-11ea-8879-07cae85ecef7.png)

Testing
* Desktop, small screen
* Chrome, FF, Edgium, Edge Legacy

Fixes #11 