### PR TITLE
Make event.detail.page and event.detail.itemCount consistently numbers

### DIFF
--- a/pagination.js
+++ b/pagination.js
@@ -73,57 +73,47 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 		this.maxPageNumber = 1;
 	}
 
-	// TODO: page number types are inconsistent depending on if event is fired from arrows or from Enter keypress
-	_submitPageNumber(e) {
-		if (!this._isValidNumber(e.target.value)) {
-			e.target.value = this.pageNumber.toString();
-			return;
-		}
-
-		const event = new CustomEvent('pagination-page-change', {
-			detail: {
-				page: e.target.value
-			},
-			bubbles: true,
-			composed: true
-		});
-		this.dispatchEvent(event);
-	}
-
 	_handleKeydown(e) {
 		if (e.key === 'Enter') {
 			this._submitPageNumber(e);
 		}
 	}
 
-	_navToPreviousPage() {
-		const newPageNumber = this.pageNumber - 1;
-		const event = new CustomEvent('pagination-page-change', {
+	_submitPageNumber(e) {
+		if (!this._isValidNumber(e.target.value)) {
+			e.target.value = this.pageNumber.toString();
+			return;
+		}
+
+		this._firePageChangeEvent(Number(e.target.value));
+	}
+
+	/**
+	 * @param {Number} newPageNumber
+	 * @private
+	 */
+	_firePageChangeEvent(newPageNumber) {
+		this.dispatchEvent(new CustomEvent('pagination-page-change', {
 			detail: {
 				page: newPageNumber
 			},
 			bubbles: true,
 			composed: true
-		});
-		this.dispatchEvent(event);
+		}));
+	}
+
+	_navToPreviousPage() {
+		this._firePageChangeEvent(this.pageNumber - 1);
 	}
 
 	_navToNextPage() {
-		const newPageNumber = this.pageNumber + 1;
-		const event = new CustomEvent('pagination-page-change', {
-			detail: {
-				page: newPageNumber
-			},
-			bubbles: true,
-			composed: true
-		});
-		this.dispatchEvent(event);
+		this._firePageChangeEvent(this.pageNumber + 1);
 	}
 
 	_pageCounterChange(e) {
 		const event = new CustomEvent('pagination-item-counter-change', {
 			detail: {
-				itemCount: e.target.value
+				itemCount: Number(e.target.value)
 			},
 			bubbles: true,
 			composed: true

--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -194,7 +194,7 @@ describe('pagination', () => {
 				pageNumberInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
 				const event = await listener;
-				expect(event.detail.page).to.equal('3');
+				expect(event.detail.page).to.equal(3);
 			});
 
 			it('should fire when new page number is valid and page input element loses focus', async() => {
@@ -208,7 +208,7 @@ describe('pagination', () => {
 				inputEl.blur();
 
 				const event = await listener;
-				expect(event.detail.page).to.equal('3');
+				expect(event.detail.page).to.equal(3);
 			});
 		});
 
@@ -239,7 +239,10 @@ describe('pagination', () => {
 
 				const result = await verifyEventTimeout(listener, 'no event fired');
 				expect(result).not.to.equal('no event fired');
-				expect(result.detail.page).to.equal('5');
+				expect(result.detail.page).to.equal(5);
+
+				// the input element's value should also be changed to the new value
+				expect(pageNumberInput.value).to.equal('5');
 			});
 
 			it('should not fire when new page number is an invalid page number', async() => {
@@ -251,12 +254,18 @@ describe('pagination', () => {
 				let result = await verifyEventTimeout(listener, 'no event fired');
 				expect(result).to.equal('no event fired');
 
+				// the input element's value should also reset to the old value
+				expect(pageNumberInput.value).to.equal('4');
+
 				listener = oneEvent(el, 'pagination-page-change');
 				pageNumberInput.value = '7';
 				pageNumberInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
 				result = await verifyEventTimeout(listener, 'no event fired');
 				expect(result).to.equal('no event fired');
+
+				// the input element's value should also reset to the old value
+				expect(pageNumberInput.value).to.equal('4');
 			});
 
 			it('should not fire when new page number is not a number', async() => {
@@ -267,6 +276,7 @@ describe('pagination', () => {
 
 				const result = await verifyEventTimeout(listener, 'no event fired');
 				expect(result).to.equal('no event fired');
+				expect(pageNumberInput.value).to.equal('4');
 			});
 
 			it('should not fire in response to keypresses that are not Enter', async() => {
@@ -277,6 +287,7 @@ describe('pagination', () => {
 
 				const result = await verifyEventTimeout(listener, 'no event fired');
 				expect(result).to.equal('no event fired');
+				expect(pageNumberInput.value).to.equal('3');
 			});
 		});
 
@@ -298,7 +309,7 @@ describe('pagination', () => {
 				pageSizeSelector.dispatchEvent(new Event('change'));
 
 				const event = await listener;
-				expect(event.detail.itemCount).to.equal('10');
+				expect(event.detail.itemCount).to.equal(10);
 			});
 		});
 	});


### PR DESCRIPTION
Before:
- `pagination-page-change`: event.detail.page was a number when switching pages with the arrow, but it was a string when switching pages due to the page input losing focus
- `pagination-item-counter-change`: event.detail.itemCount was always a string

After: 
- `pagination-page-change`: event.detail.page is a number, regardless of what caused the event
- `pagination-item-counter-change`: event.detail.itemCount is a number now

The change to `pagination-item-counter-change` wasn't strictly required - it was based on my personal taste. Let me know if there are any reasons why itemCount should be a string instead.