### PR TITLE
A11y-label page selector input

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@brightspace-ui/stylelint-config"
+}

--- a/lang/en.js
+++ b/lang/en.js
@@ -5,4 +5,5 @@ export default {
 	page_previous : "Previous page",
 	page_size_option : "{count} per page",
 	page_size_title : "Results per page",
+	page_number_title: "Page number {pageNumber} of {maxPageNumber}"
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -2,8 +2,8 @@
 
 export default {
 	page_next : "Next page",
+	page_number_title: "Page number {pageNumber} of {maxPageNumber}",
 	page_previous : "Previous page",
 	page_size_option : "{count} per page",
-	page_size_title : "Results per page",
-	page_number_title: "Page number {pageNumber} of {maxPageNumber}"
+	page_size_title : "Results per page"
 };

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "/lang"
   ],
   "scripts": {
-    "lint": "npm run lint:eslint && npm run lint:lit",
+    "lint": "npm run lint:eslint && npm run lint:lit && npm run lint:style",
     "lint:eslint": "eslint . --ext .js,.html",
     "lint:lit": "lit-analyzer --rules.no-complex-attribute-binding off --rules.no-incompatible-type-binding off pagination.js demo test",
+    "lint:style": "stylelint \"**/*.js\"",
     "start": "es-dev-server --app-index demo/index.html --node-resolve --dedupe --open --watch",
     "test": "npm run lint && npm run test:headless",
     "test:headless": "karma start",
@@ -28,6 +29,7 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@brightspace-ui/stylelint-config": "0.0.1",
     "@brightspace-ui/visual-diff": "^1",
     "@open-wc/testing": "^2",
     "@open-wc/testing-karma": "^3",
@@ -42,7 +44,8 @@
     "frau-ci": "^1",
     "karma-sauce-launcher": "^2",
     "lit-analyzer": "^1",
-    "puppeteer": "^1"
+    "puppeteer": "^1",
+    "stylelint": "^13.6.1"
   },
   "dependencies": {
     "@brightspace-ui/core": "^1.43.4",

--- a/pagination.js
+++ b/pagination.js
@@ -142,20 +142,21 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 	render() {
 		return html`
 			<div class="pagination-container page-selector-container">
-				<d2l-button-icon icon="d2l-tier1:chevron-left" @click="${this._navToPreviousPage}" text="${this.localize('page_previous')}" ?disabled=${this.disablePreviousPageButton()}></d2l-button-icon>
+				<d2l-button-icon icon="tier1:chevron-left" @click="${this._navToPreviousPage}" text="${this.localize('page_previous')}" ?disabled=${this.disablePreviousPageButton()}></d2l-button-icon>
 				<d2l-input-text
 					class="page-number"
 					autocomplete="off"
 					autocorrect="off"
 					type="text"
-					aria-label="page_number_title"
+					aria-label="${this.localize('page_number_title', {pageNumber: this.pageNumber, maxPageNumber: this.maxPageNumber})}"
 					value="${this.pageNumber}"
 					@blur="${this._submitPageNumber}"
 					@keydown="${this._handleKeydown}"
 				></d2l-input-text>
 				<!-- Note: this uses a division slash rather than a regular slash -->
-				<span class="page-max">∕ ${this.maxPageNumber}</span>
-				<d2l-button-icon icon="d2l-tier1:chevron-right" @click="${this._navToNextPage}" text="${this.localize('page_next')}" ?disabled=${this.disableNextPageButton()}></d2l-button-icon>
+				<!-- a11y note: setting aria-hidden to true because it's covered by the previous element -->
+				<span class="page-max" aria-hidden="true">∕ ${this.maxPageNumber}</span>
+				<d2l-button-icon icon="tier1:chevron-right" @click="${this._navToNextPage}" text="${this.localize('page_next')}" ?disabled=${this.disableNextPageButton()}></d2l-button-icon>
 			</div>
 
 			${this.showItemCountSelect ? html`

--- a/pagination.js
+++ b/pagination.js
@@ -148,7 +148,8 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 					autocomplete="off"
 					autocorrect="off"
 					type="text"
-					aria-label="${this.localize('page_number_title', {pageNumber: this.pageNumber, maxPageNumber: this.maxPageNumber})}"
+					label="${this.localize('page_number_title', {pageNumber: this.pageNumber, maxPageNumber: this.maxPageNumber})}"
+					label-hidden
 					value="${this.pageNumber}"
 					@blur="${this._submitPageNumber}"
 					@keydown="${this._handleKeydown}"

--- a/pagination.js
+++ b/pagination.js
@@ -121,11 +121,11 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 		this.dispatchEvent(event);
 	}
 
-	disablePreviousPageButton() {
+	_disablePreviousPageButton() {
 		return this.pageNumber <= 1;
 	}
 
-	disableNextPageButton() {
+	_disableNextPageButton() {
 		return this.pageNumber >= this.maxPageNumber;
 	}
 
@@ -142,7 +142,7 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 	render() {
 		return html`
 			<div class="pagination-container page-selector-container">
-				<d2l-button-icon icon="tier1:chevron-left" @click="${this._navToPreviousPage}" text="${this.localize('page_previous')}" ?disabled=${this.disablePreviousPageButton()}></d2l-button-icon>
+				<d2l-button-icon icon="tier1:chevron-left" @click="${this._navToPreviousPage}" text="${this.localize('page_previous')}" ?disabled=${this._disablePreviousPageButton()}></d2l-button-icon>
 				<d2l-input-text
 					class="page-number"
 					autocomplete="off"
@@ -157,7 +157,7 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 				<!-- Note: this uses a division slash rather than a regular slash -->
 				<!-- a11y note: setting aria-hidden to true because it's covered by the previous element -->
 				<span class="page-max" aria-hidden="true">∕ ${this.maxPageNumber}</span>
-				<d2l-button-icon icon="tier1:chevron-right" @click="${this._navToNextPage}" text="${this.localize('page_next')}" ?disabled=${this.disableNextPageButton()}></d2l-button-icon>
+				<d2l-button-icon icon="tier1:chevron-right" @click="${this._navToNextPage}" text="${this.localize('page_next')}" ?disabled=${this._disableNextPageButton()}></d2l-button-icon>
 			</div>
 
 			${this.showItemCountSelect ? html`

--- a/pagination.js
+++ b/pagination.js
@@ -23,10 +23,10 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 	static get styles() {
 		return [selectStyles, css`
 			:host {
+				align-content: center;
+				align-items: center;
 				display: flex;
 				flex-direction: row;
-				align-items: center;
-				align-content: center;
 				justify-content: center;
 				white-space: nowrap;
 			}
@@ -41,26 +41,26 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 				}
 			}
 
-			.pagination-container {
+			.d2l-pagination-container {
 				display: block;
 			}
 
-			.page-selector-container {
+			.d2l-page-selector-container {
 				margin: 15px;
 			}
 
-			.page-selector-container > * {
+			.d2l-page-selector-container > * {
 				display: inline-flex;
 			}
 
-			.page-number {
-				margin-left: .25rem;
-				margin-right: .25rem;
+			.d2l-page-number {
+				margin-left: 0.25rem;
+				margin-right: 0.25rem;
 				width: 4em;
 			}
 
-			.page-max {
-				margin-right: .25rem;
+			.d2l-page-max-text {
+				margin-right: 0.25rem;
 				vertical-align: middle;
 			}
 		`];
@@ -141,10 +141,10 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 
 	render() {
 		return html`
-			<div class="pagination-container page-selector-container">
+			<div class="d2l-pagination-container d2l-page-selector-container">
 				<d2l-button-icon icon="tier1:chevron-left" @click="${this._navToPreviousPage}" text="${this.localize('page_previous')}" ?disabled=${this._disablePreviousPageButton()}></d2l-button-icon>
 				<d2l-input-text
-					class="page-number"
+					class="d2l-page-number"
 					autocomplete="off"
 					autocorrect="off"
 					type="text"
@@ -156,12 +156,12 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 				></d2l-input-text>
 				<!-- Note: this uses a division slash rather than a regular slash -->
 				<!-- a11y note: setting aria-hidden to true because it's covered by the previous element -->
-				<span class="page-max" aria-hidden="true">∕ ${this.maxPageNumber}</span>
+				<span class="d2l-page-max-text" aria-hidden="true">∕ ${this.maxPageNumber}</span>
 				<d2l-button-icon icon="tier1:chevron-right" @click="${this._navToNextPage}" text="${this.localize('page_next')}" ?disabled=${this._disableNextPageButton()}></d2l-button-icon>
 			</div>
 
 			${this.showItemCountSelect ? html`
-				<div class="pagination-container">
+				<div class="d2l-pagination-container">
 					<select
 						aria-label="${this.localize('page_size_title')}"
 						title="${this.localize('page_size_title')}"

--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -85,8 +85,8 @@ describe('pagination', () => {
 						dir="${dir}"
 					></d2l-labs-pagination>`
 				);
-				const leftButton = el.shadowRoot.querySelector('d2l-button-icon[icon="d2l-tier1:chevron-left"]');
-				const rightButton = el.shadowRoot.querySelector('d2l-button-icon[icon="d2l-tier1:chevron-right"]');
+				const leftButton = el.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-left"]');
+				const rightButton = el.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-right"]');
 
 				return {el, leftButton, rightButton};
 			}
@@ -171,8 +171,8 @@ describe('pagination', () => {
 			});
 
 			it('should fire when arrows are clickable and have been clicked', async() => {
-				const leftButton = el.shadowRoot.querySelector('d2l-button-icon[icon="d2l-tier1:chevron-left"]');
-				const rightButton = el.shadowRoot.querySelector('d2l-button-icon[icon="d2l-tier1:chevron-right"]');
+				const leftButton = el.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-left"]');
+				const rightButton = el.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-right"]');
 
 				let listener = oneEvent(el, 'pagination-page-change');
 				leftButton.click();

--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -39,7 +39,7 @@ describe('pagination', () => {
 				html`<d2l-labs-pagination pageNumber="3" maxPageNumber="8"></d2l-labs-pagination>`
 			);
 			const pageInput = el.shadowRoot.querySelector('d2l-input-text');
-			const maxPageIndicator = el.shadowRoot.querySelector('span.page-max');
+			const maxPageIndicator = el.shadowRoot.querySelector('span.d2l-page-max-text');
 			expect(pageInput.value).to.equal('3');
 			expect(maxPageIndicator.innerText).to.equal('∕ 8');
 
@@ -59,7 +59,7 @@ describe('pagination', () => {
 				></d2l-labs-pagination>`
 			);
 			const pageNumberInput = el.shadowRoot.querySelector('d2l-input-text');
-			const maxPageIndicator = el.shadowRoot.querySelector('span.page-max');
+			const maxPageIndicator = el.shadowRoot.querySelector('span.d2l-page-max-text');
 			expect(pageNumberInput.value).to.equal('3');
 			expect(maxPageIndicator.innerText).to.equal('∕ 8');
 


### PR DESCRIPTION
Adds an accessible label to the page input element (as suggested in #14 )

Testing:
* NVDA, on Chrome, FF, Edgium, Edge Legacy
* Used tab button to navigate between controls

Transcript
```
Chrome
Previous page  button  Previous page
Page number 2 of 3  edit  selected 2
Next page  button  Next page

Firefox
clickable  Previous page  button  
Page number 2 of 3  edit  selected 2
clickable  Next page  button  

Edgium
clickable  Previous page  button    Previous page
Page number 2 of 3  edit  selected 2
clickable  Next page  button    Next page

Edge Legacy
Previous page  button    Previous page
Page number 2 of 3  edit  selected 2
Next page  button    Next page
```

If the prev or next page buttons are disabled, tabbing will pass over them and go directly to the next element.

Fixes #17 
Fixes #18 

FYI @anhill-D2L 