### PR TITLE
Kebab case properties

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -17,19 +17,26 @@
 			<h2>d2l-labs-pagination</h2>
 
 			<d2l-demo-snippet>
-				<d2l-labs-pagination id="pagination-1" pageNumber="1" maxPageNumber="1"></d2l-labs-pagination>
+				<d2l-labs-pagination id="pagination-1" page-number="1" max-page-number="1"></d2l-labs-pagination>
 			</d2l-demo-snippet>
 
 			<d2l-demo-snippet>
-				<d2l-labs-pagination id="pagination-2" pageNumber="2" maxPageNumber="3"></d2l-labs-pagination>
+				<d2l-labs-pagination id="pagination-2" page-number="2" max-page-number="3"></d2l-labs-pagination>
 			</d2l-demo-snippet>
 
 			<d2l-demo-snippet>
-				<d2l-labs-pagination id="pagination-3" pageNumber="5" maxPageNumber="5"></d2l-labs-pagination>
+				<d2l-labs-pagination id="pagination-3" page-number="5" max-page-number="5"></d2l-labs-pagination>
 			</d2l-demo-snippet>
 
 			<d2l-demo-snippet>
-				<d2l-labs-pagination id="pagination-4" pageNumber="5" maxPageNumber="5" showItemCountSelect itemCountOptions="[1,10,20,100,2987]" selectedCountOption="10"></d2l-labs-pagination>
+				<d2l-labs-pagination
+					id="pagination-4"
+					page-number="5"
+					max-page-number="5"
+					show-item-count-select
+					item-count-options="[1,10,20,100,2987]"
+					selected-count-option="10"
+				></d2l-labs-pagination>
 			</d2l-demo-snippet>
 		</d2l-demo-page>
 

--- a/pagination.js
+++ b/pagination.js
@@ -9,11 +9,11 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 
 	static get properties() {
 		return {
-			pageNumber: { type: Number, attribute: 'page-number' },
-			maxPageNumber: { type: Number, attribute: 'max-page-number' },
-			showItemCountSelect : { type: Boolean, attribute: 'show-item-count-select' },
+			pageNumber: { type: Number, attribute: 'page-number', reflect: true },
+			maxPageNumber: { type: Number, attribute: 'max-page-number', reflect: true },
+			showItemCountSelect : { type: Boolean, attribute: 'show-item-count-select', reflect: true },
 			itemCountOptions : { type: Array, attribute: 'item-count-options' },
-			selectedCountOption : { type: Number, attribute: 'selected-count-option' },
+			selectedCountOption : { type: Number, attribute: 'selected-count-option', reflect: true },
 		};
 	}
 

--- a/pagination.js
+++ b/pagination.js
@@ -9,14 +9,11 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 
 	static get properties() {
 		return {
-			pageNumber: { type: Number },
-			maxPageNumber: { type: Number },
-			showItemCountSelect : { type: Boolean },
-			itemCountOptions : { type: Array },
-			selectedCountOption : {type: Number},
-
-			_disablePrevPage: { type: Boolean },
-			_disableNextPage: { type: Boolean },
+			pageNumber: { type: Number, attribute: 'page-number' },
+			maxPageNumber: { type: Number, attribute: 'max-page-number' },
+			showItemCountSelect : { type: Boolean, attribute: 'show-item-count-select' },
+			itemCountOptions : { type: Array, attribute: 'item-count-options' },
+			selectedCountOption : { type: Number, attribute: 'selected-count-option' },
 		};
 	}
 
@@ -155,7 +152,7 @@ class Pagination extends RtlMixin(Localizer(LitElement)) {
 					@keydown="${this._handleKeydown}"
 				></d2l-input-text>
 				<!-- Note: this uses a division slash rather than a regular slash -->
-				<!-- a11y note: setting aria-hidden to true because it's covered by the previous element -->
+				<!-- a11y note: setting aria-hidden to true because info here is covered by input element -->
 				<span class="d2l-page-max-text" aria-hidden="true">∕ ${this.maxPageNumber}</span>
 				<d2l-button-icon icon="tier1:chevron-right" @click="${this._navToNextPage}" text="${this.localize('page_next')}" ?disabled=${this._disableNextPageButton()}></d2l-button-icon>
 			</div>

--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -14,11 +14,11 @@ describe('pagination', () => {
 		it('should pass all axe tests (full)', async() => {
 			const el = await fixture(
 				html`<d2l-labs-pagination
-					pageNumber="1"
-					maxPageNumber="6"
-					showItemCountSelect
-					itemCountOptions="[10, 20, 50, 100]"
-					selectedCountOption="20"
+					page-number="1"
+					max-page-number="6"
+					show-item-count-select
+					item-count-options="[10, 20, 50, 100]"
+					selected-count-option="20"
 				>
 				</d2l-labs-pagination>`
 			);
@@ -36,7 +36,7 @@ describe('pagination', () => {
 	describe('render', () => {
 		it('should render page number and max page number correctly', async() => {
 			const el = await fixture(
-				html`<d2l-labs-pagination pageNumber="3" maxPageNumber="8"></d2l-labs-pagination>`
+				html`<d2l-labs-pagination page-number="3" max-page-number="8"></d2l-labs-pagination>`
 			);
 			const pageInput = el.shadowRoot.querySelector('d2l-input-text');
 			const maxPageIndicator = el.shadowRoot.querySelector('span.d2l-page-max-text');
@@ -51,11 +51,11 @@ describe('pagination', () => {
 		it('should render page size selector with correct options and initial selection', async() => {
 			const el = await fixture(html`
 				<d2l-labs-pagination
-					pageNumber="3"
-					maxPageNumber="8"
-					showItemCountSelect
-					itemCountOptions="[2,5,37,159]"
-					selectedCountOption="37"
+					page-number="3"
+					max-page-number="8"
+					show-item-count-select
+					item-count-options="[2,5,37,159]"
+					selected-count-option="37"
 				></d2l-labs-pagination>`
 			);
 			const pageNumberInput = el.shadowRoot.querySelector('d2l-input-text');
@@ -80,8 +80,8 @@ describe('pagination', () => {
 			async function getPaginationEl(pageNumber, maxPages, dir) {
 				const el = await fixture(
 					html`<d2l-labs-pagination
-						pageNumber="${pageNumber}"
-						maxPageNumber="${maxPages}"
+						page-number="${pageNumber}"
+						max-page-number="${maxPages}"
 						dir="${dir}"
 					></d2l-labs-pagination>`
 				);
@@ -166,7 +166,7 @@ describe('pagination', () => {
 			let el;
 			beforeEach(async() => {
 				el = await fixture(
-					html`<d2l-labs-pagination pageNumber="2" maxPageNumber="3"></d2l-labs-pagination>`
+					html`<d2l-labs-pagination page-number="2" max-page-number="3"></d2l-labs-pagination>`
 				);
 			});
 
@@ -227,7 +227,7 @@ describe('pagination', () => {
 
 			beforeEach(async() => {
 				el = await fixture(
-					html`<d2l-labs-pagination pageNumber="4" maxPageNumber="5"></d2l-labs-pagination>`
+					html`<d2l-labs-pagination page-number="4" max-page-number="5"></d2l-labs-pagination>`
 				);
 			});
 
@@ -295,11 +295,11 @@ describe('pagination', () => {
 			it('should fire when the page size selector value changes', async() => {
 				const el = await fixture(
 					html`<d2l-labs-pagination
-						pageNumber="2"
-						maxPageNumber="3"
-						showItemCountSelect
-						itemCountOptions="[10, 20, 50, 100]"
-						selectedCountOption="20"
+						page-number="2"
+						max-page-number="3"
+						show-item-count-select
+						item-count-options="[10, 20, 50, 100]"
+						selected-count-option="20"
 					></d2l-labs-pagination>`
 				);
 


### PR DESCRIPTION
I added this component to a parent component that dynamically changed the current page and max page numbers. The changes were not being applied in Edge. Changing the properties to kebab-case seemed to fix it, so I'm doing that change here as well.

More context: https://d2l.slack.com/archives/C0PHG3QB0/p1588276466308300

I also set the properties to `reflect: true` (except `itemCountOptions` since that should really be an array I think) as described in the [best practices guide](https://github.com/BrightspaceUI/guide/wiki/LitElement-Best-Practices-&-Gotchas#-do-reflect-properties-back-to-attributes). 

Testing
- Demo page looks and behaves the same as before in Chrome, FF, Edgium, Edge Legacy
- Changing one of the properties in JS does reflect it back to the DOM (checked Chrome, Edge Legacy)