### PR TITLE
triggering a major release

### DIFF
--- a/karma.sauce.conf.js
+++ b/karma.sauce.conf.js
@@ -6,17 +6,17 @@ const customLaunchers = {
 	chrome: {
 		base: 'SauceLabs',
 		browserName: 'chrome',
-		platform: 'OS X 10.13',
+		platform: 'OS X 10.15',
 	},
 	firefox: {
 		base: 'SauceLabs',
 		browserName: 'firefox',
-		platform: 'OS X 10.13'
+		platform: 'OS X 10.15'
 	},
 	safari: {
 		base: 'SauceLabs',
 		browserName: 'safari',
-		platform: 'OS X 10.13'
+		platform: 'OS X 10.15'
 	},
 	edge: {
 		base: 'SauceLabs',


### PR DESCRIPTION
BREAKING CHANGE: not really, but we want to go to version 1.0.0 to avoid semver issues