### PR TITLE
ci: Remove visual diff for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,23 +100,6 @@ npm run test:headless
 npm run test:headless:watch
 ```
 
-### Visual Diff Testing
-
-This repo uses the [@brightspace-ui/visual-diff utility](https://github.com/BrightspaceUI/visual-diff/) to compare current snapshots against a set of golden snapshots stored in source control.
-
-```shell
-# run visual-diff tests
-npm run test:diff
-
-# subset of visual-diff tests:
-npm run test:diff -- -g some-pattern
-
-# update visual-diff goldens
-npm run test:diff:golden
-```
-
-Golden snapshots in source control must be updated by Travis CI. To trigger an update, press the "Regenerate Goldens" button in the pull request `visual-difference` test run.
-
 ## Versioning & Releasing
 
 > TL;DR: Commits prefixed with `fix:` and `feat:` will trigger patch and minor releases when merged to `master`. Read on for more details...

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@brightspace-ui/stylelint-config": "0.0.1",
-    "@brightspace-ui/visual-diff": "^1",
     "@open-wc/testing": "^2",
     "@open-wc/testing-karma": "^3",
     "@webcomponents/webcomponentsjs": "^2",
@@ -44,7 +43,6 @@
     "eslint-plugin-sort-class-members": "^1",
     "karma-sauce-launcher": "^2",
     "lit-analyzer": "^1",
-    "puppeteer": "^1",
     "stylelint": "^13.6.1"
   },
   "dependencies": {


### PR DESCRIPTION
There aren't any visual-diff tests in this repo yet, so removing the dependencies in `package.json` (which are being removed from all repos anyways) and the readme reference and workflow can be added once tests are added.